### PR TITLE
Optimize performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,10 @@ module.exports = function *parallel(thunks, n){
   var index = 0;
 
   function *next() {
-    var i = index++;
-    ret[i] = yield thunks[i];
-    if (index < thunks.length) yield next;
+    while(index < thunks.length) {
+      var i = index++;
+      ret[i] = yield thunks[i];
+    }
   }
 
   yield thread(next, n);


### PR DESCRIPTION
Normally speaking, the loop version is better than recursive one in terms of system load, especially the size of thunks is huge && high concurrency count, we will get memory stackoverflow error.